### PR TITLE
Legger til intern.dev.nav.no ingress

### DIFF
--- a/.deploy/nais/nais_dev.yaml
+++ b/.deploy/nais/nais_dev.yaml
@@ -33,7 +33,8 @@ spec:
   secureLogs:
     enabled: true
   ingresses:
-    - https://infotrygd-feed-proxy.dev.intern.nav.no
+    - https://infotrygd-feed-proxy.dev.intern.nav.no #deprekeres. Kan slettes hvis ikke infotrygd bruker denne
+    - https://infotrygd-feed-proxy.intern.dev.nav.no
     - https://infotrygd-feed-proxy.dev-fss-pub.nais.io
   vault:
     enabled: true


### PR DESCRIPTION
Legger til ny ingress som skal ta over for dev.intern.nav.no

Hvilken ingress bruker infotrygd konsumenten? dev-fss-pub.nais.io?